### PR TITLE
feat(pdf): automatically close idle pages and browsers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ CHROMIUM_BINARY_PATH="/usr/bin/chromium"
 # Concurrency
 MAX_CHROMIUM_BROWSERS=1
 MAX_CHROMIUM_TABS_PER_BROWSER=4
+MAX_IDLE_SECONDS=30
 
 # Authentication
 AUTH_SECRET="{{ auth_secret }}"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ docker run -p 3000:3000 -e AWS_S3_ENDPOINT_URL=http://localhost:9000 \
   -e CHROMIUM_BINARY_PATH=/usr/bin/chromium \
   -e MAX_CHROMIUM_BROWSERS=1 \
   -e MAX_CHROMIUM_TABS_PER_BROWSER=4 \
+  -e MAX_IDLE_SECONDS=30 \
   -e ENVIRONMENT=production \
   serpentarius
 ```
@@ -86,21 +87,22 @@ docker run -p 3000:3000 -e AWS_S3_ENDPOINT_URL=http://localhost:9000 \
 
 For any installation method, configure these variables in a `.env` file or in the environment:
 
-| Name                            | Description                                    | Development Value                                                                    |
-| ------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `AWS_S3_ENDPOINT_URL`           | S3 endpoint URL                                | `http://localhost:9000`                                                              |
-| `AwsAccessKeyID`                | AWS access key ID                              | Create a Bucket and copy the `Access Key ID` of a user with access to the Bucket     |
-| `AwsSecretAccessKey`            | AWS secret access key                          | Create a Bucket and copy the `Secret Access Key` of a user with access to the Bucket |
-| `AwsRegion`                     | AWS region where the Bucket is located         | Default value is `us-east-1`                                                         |
-| `REDIS_HOST`                    | Redis server hostname                          | `localhost`                                                                          |
-| `REDIS_PORT`                    | Redis server port                              | `6379`                                                                               |
-| `REDIS_PASSWORD`                | Redis server password                          | `dragonfly`                                                                          |
-| `REDIS_DB`                      | Redis database to use                          | `0`                                                                                  |
-| `AUTH_SECRET`                   | Secret key for user authentication             | No default value                                                                     |
-| `CHROMIUM_BINARY_PATH`          | Path to the Chromium binary                    | `/usr/bin/chromium`                                                                  |
-| `MAX_CHROMIUM_BROWSERS`         | Maximum number of concurrent Chromium browsers | `1`                                                                                  |
-| `MAX_CHROMIUM_TABS_PER_BROWSER` | Maximum number of tabs per Chromium browser    | `4`                                                                                  |
-| `Environment`                   | Execution environment (development/production) | `development`                                                                        |
+| Name                            | Description                                                | Development Value                                                                    |
+| ------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `AWS_S3_ENDPOINT_URL`           | S3 endpoint URL                                            | `http://localhost:9000`                                                              |
+| `AWS_ACCESS_KEY_ID`             | AWS access key ID                                          | Create a Bucket and copy the `Access Key ID` of a user with access to the Bucket     |
+| `AWS_SECRET_ACCESS_KEY`         | AWS secret access key                                      | Create a Bucket and copy the `Secret Access Key` of a user with access to the Bucket |
+| `AWS_REGION`                    | AWS region where the Bucket is located                     | Default value is `us-east-1`                                                         |
+| `REDIS_HOST`                    | Redis server hostname                                      | `localhost`                                                                          |
+| `REDIS_PORT`                    | Redis server port                                          | `6379`                                                                               |
+| `REDIS_PASSWORD`                | Redis server password                                      | `dragonfly`                                                                          |
+| `REDIS_DB`                      | Redis database to use                                      | `0`                                                                                  |
+| `AUTH_SECRET`                   | Secret key for user authentication                         | No default value                                                                     |
+| `CHROMIUM_BINARY_PATH`          | Path to the Chromium binary                                | `/usr/bin/chromium`                                                                  |
+| `MAX_CHROMIUM_BROWSERS`         | Maximum number of concurrent Chromium browsers             | `1`                                                                                  |
+| `MAX_CHROMIUM_TABS_PER_BROWSER` | Maximum number of tabs per Chromium browser                | `4`                                                                                  |
+| `MAX_IDLE_SECONDS`              | Maximum seconds a page can remain idle before being closed | `30`                                                                                 |
+| `ENVIRONMENT`                   | Execution environment (development/production)             | `development`                                                                        |
 
 The values shown in the `Development Value` column are compatible with the `container-compose.yml` file included in the project, which configures Dragonfly (Redis alternative) and MinIO (S3 alternative) for local development. If you use your own servers, adjust these variables accordingly.
 

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -78,6 +78,7 @@ docker run -p 3000:3000 -e AWS_S3_ENDPOINT_URL=http://localhost:9000 \
   -e CHROMIUM_BINARY_PATH=/usr/bin/chromium \
   -e MAX_CHROMIUM_BROWSERS=1 \
   -e MAX_CHROMIUM_TABS_PER_BROWSER=4 \
+  -e MAX_IDLE_SECONDS=30 \
   -e ENVIRONMENT=production \
   serpentarius
 ```
@@ -86,21 +87,22 @@ docker run -p 3000:3000 -e AWS_S3_ENDPOINT_URL=http://localhost:9000 \
 
 Para cualquier método de instalación, configura estas variables en un archivo `.env` o en el entorno:
 
-| Nombre                          | Descripción                                        | Valor para desarrollo                                                                          |
-| ------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `AWS_S3_ENDPOINT_URL`           | URL del endpoint de S3                             | `http://localhost:9000`                                                                        |
-| `AwsAccessKeyID`                | ID de la clave de acceso de AWS                    | Debes crear un Bucket y copiar el `Access Key ID` de un usuario que tenga acceso al Bucket     |
-| `AwsSecretAccessKey`            | Clave de acceso secreta de AWS                     | Debes crear un Bucket y copiar el `Secret Access Key` de un usuario que tenga acceso al Bucket |
-| `AwsRegion`                     | Región de AWS donde se encuentra el Bucket         | Por defecto se usa el valor `us-east-1`                                                        |
-| `REDIS_HOST`                    | Hostname del servidor Redis                        | `localhost`                                                                                    |
-| `REDIS_PORT`                    | Puerto del servidor Redis                          | `6379`                                                                                         |
-| `REDIS_PASSWORD`                | Contraseña del servidor Redis                      | `dragonfly`                                                                                    |
-| `REDIS_DB`                      | Base de datos de Redis a utilizar                  | `0`                                                                                            |
-| `AUTH_SECRET`                   | Clave secreta para la autenticación de usuarios    | No se establece valor por defecto                                                              |
-| `CHROMIUM_BINARY_PATH`          | Ruta al binario de Chromium                        | `/usr/bin/chromium`                                                                            |
-| `MAX_CHROMIUM_BROWSERS`         | Número máximo de navegadores Chromium concurrentes | `1`                                                                                            |
-| `MAX_CHROMIUM_TABS_PER_BROWSER` | Número máximo de pestañas por navegador Chromium   | `4`                                                                                            |
-| `Environment`                   | Entorno de ejecución (development/production)      | `development`                                                                                  |
+| Nombre                          | Descripción                                                            | Valor para desarrollo                                                                          |
+| ------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `AWS_S3_ENDPOINT_URL`           | URL del endpoint de S3                                                 | `http://localhost:9000`                                                                        |
+| `AWS_ACCESS_KEY_ID`             | ID de la clave de acceso de AWS                                        | Debes crear un Bucket y copiar el `Access Key ID` de un usuario que tenga acceso al Bucket     |
+| `AWS_SECRET_ACCESS_KEY`         | Clave de acceso secreta de AWS                                         | Debes crear un Bucket y copiar el `Secret Access Key` de un usuario que tenga acceso al Bucket |
+| `AWS_REGION`                    | Región de AWS donde se encuentra el Bucket                             | Por defecto se usa el valor `us-east-1`                                                        |
+| `REDIS_HOST`                    | Hostname del servidor Redis                                            | `localhost`                                                                                    |
+| `REDIS_PORT`                    | Puerto del servidor Redis                                              | `6379`                                                                                         |
+| `REDIS_PASSWORD`                | Contraseña del servidor Redis                                          | `dragonfly`                                                                                    |
+| `REDIS_DB`                      | Base de datos de Redis a utilizar                                      | `0`                                                                                            |
+| `AUTH_SECRET`                   | Clave secreta para la autenticación de usuarios                        | No se establece valor por defecto                                                              |
+| `CHROMIUM_BINARY_PATH`          | Ruta al binario de Chromium                                            | `/usr/bin/chromium`                                                                            |
+| `MAX_CHROMIUM_BROWSERS`         | Número máximo de navegadores Chromium concurrentes                     | `1`                                                                                            |
+| `MAX_CHROMIUM_TABS_PER_BROWSER` | Número máximo de pestañas por navegador Chromium                       | `4`                                                                                            |
+| `MAX_IDLE_SECONDS`              | Segundos máximos que una página puede estar inactiva antes de cerrarse | `30`                                                                                           |
+| `ENVIRONMENT`                   | Entorno de ejecución (development/production)                          | `development`                                                                                  |
 
 Los valores mostrados en la columna `Valor para desarrollo` son compatibles con el archivo `container-compose.yml` incluido en el proyecto, que configura Dragonfly (alternativa a Redis) y MinIO (alternativa a S3) para desarrollo local. Si usas tus propios servidores, ajusta estas variables según corresponda.
 

--- a/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
+++ b/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
+
+	"slices"
 
 	"github.com/PChaparro/serpentarius/internal/modules/pdf/domain/dto"
 	sharedInfrastructure "github.com/PChaparro/serpentarius/internal/modules/shared/infrastructure"
@@ -28,6 +31,9 @@ var (
 
 	// MaxPagesPerBrowser defines the maximum number of pages per browser instance
 	MaxPagesPerBrowser = sharedInfrastructure.GetEnvironment().MaxChromiumTabsPerBrowser
+
+	// PageIdleTimeout defines how long a page can remain idle before being closed
+	PageIdleTimeout = time.Duration(sharedInfrastructure.GetEnvironment().MaxIdleSeconds) * time.Second
 )
 
 // PageWithBrowser associates a Rod Page with its parent Browser instance.
@@ -37,14 +43,34 @@ type PageWithBrowser struct {
 	Browser *rod.Browser // The parent browser instance that owns this page
 }
 
+// PageWithTimeout extends PageWithBrowser to include timeout management.
+// This structure is used to track pages and their activity for dynamic resource management.
+type PageWithTimeout struct {
+	Page      *rod.Page    // The browser page instance for rendering content
+	Browser   *rod.Browser // The parent browser instance that owns this page
+	LastUsed  time.Time    // Timestamp when the page was last returned to the pool
+	Timer     *time.Timer  // Timer to track inactivity and trigger cleanup
+	InUse     bool         // Whether this page is currently being used
+	BrowserID string       // Unique identifier for the browser
+}
+
+// BrowserInfo tracks information about a browser instance
+type BrowserInfo struct {
+	Browser   *rod.Browser       // The browser instance
+	PageCount int                // Current number of pages (tabs) in this browser
+	Pages     []*PageWithTimeout // References to pages created with this browser
+	ID        string             // Unique identifier for this browser
+}
+
 // PDFGeneratorRod implements PDF generation functionality using the Rod library
-// to control headless Chrome browsers. It maintains a pool of browser instances and pages
-// to optimize resource usage and improve performance with concurrent PDF generation tasks.
+// to control headless Chrome browsers. It dynamically manages browser and page resources,
+// creating them on-demand and cleaning them up after periods of inactivity.
 type PDFGeneratorRod struct {
-	pagePool    chan *PageWithBrowser // Pool of available browser pages for PDF generation
-	mutex       sync.Mutex            // Mutex to protect concurrent access to the generator state
-	initialized bool                  // Flag indicating if the generator has been initialized
-	browsers    []*rod.Browser        // List of browser instances managed by this generator
+	mutex          sync.Mutex              // Mutex to protect concurrent access to the generator state
+	browsers       map[string]*BrowserInfo // Map of browser instances by their unique IDs
+	availablePages []*PageWithTimeout      // List of available pages
+	waitingQueue   []chan *PageWithTimeout // Channels for clients waiting for a page
+	pageWaitGroup  sync.WaitGroup          // Used to track when pages are being used
 }
 
 // Global singleton instance and initialization control
@@ -58,8 +84,11 @@ var pdfGeneratorOnce sync.Once
 // managing the browser pool across the application.
 func GetPDFGeneratorRod() *PDFGeneratorRod {
 	pdfGeneratorOnce.Do(func() {
-		pdfGeneratorInstance = &PDFGeneratorRod{}
-		pdfGeneratorInstance.Initialize()
+		pdfGeneratorInstance = &PDFGeneratorRod{
+			browsers:       make(map[string]*BrowserInfo),
+			availablePages: make([]*PageWithTimeout, 0),
+			waitingQueue:   make([]chan *PageWithTimeout, 0),
+		}
 
 		// Set up a finalizer to clean up resources when the generator is garbage collected
 		runtime.SetFinalizer(pdfGeneratorInstance, func(p *PDFGeneratorRod) {
@@ -70,70 +99,272 @@ func GetPDFGeneratorRod() *PDFGeneratorRod {
 	return pdfGeneratorInstance
 }
 
-// Initialize sets up the browser pool and page pool for PDF generation.
-// It creates multiple browser instances and initializes pages for each browser,
-// adding them to the page pool for future use. This method is thread-safe
-// and will only initialize the generator once, regardless of how many times it's called.
-func (p *PDFGeneratorRod) Initialize() {
+// createBrowser launches a new browser instance and adds it to the pool
+func (p *PDFGeneratorRod) createBrowser() (*BrowserInfo, error) {
+	// Launch a new browser instance with optimized settings for headless PDF generation
+	launcherURL := launcher.New().
+		Bin(sharedInfrastructure.GetEnvironment().ChromiumBinaryPath). // Use the configured Chromium binary
+		Headless(true).                                                // Run in headless mode (no UI)
+		Leakless(true).                                                // Ensure process cleanup on unexpected termination
+		Set("disable-gpu", "1").                                       // Disable GPU acceleration
+		Set("disable-dev-shm-usage", "1").                             // Avoid using shared memory
+		Set("disable-extensions", "1").                                // Disable browser extensions
+		MustLaunch()
+
+	// Connect to the launched browser
+	browser := rod.New().ControlURL(launcherURL).MustConnect()
+
+	// Generate a unique ID for this browser
+	browserID := sharedInfrastructure.GenerateXID()
+
+	// Create browser info
+	info := &BrowserInfo{
+		Browser:   browser,
+		PageCount: 0,
+		Pages:     make([]*PageWithTimeout, 0),
+		ID:        browserID,
+	}
+
+	// Store in browsers map
+	p.browsers[browserID] = info
+
+	sharedInfrastructure.GetLogger().
+		WithField("browser_id", browserID).
+		Info("Created new browser instance")
+
+	return info, nil
+}
+
+// createPage creates a new page in the given browser
+func (p *PDFGeneratorRod) createPage(browserInfo *BrowserInfo) (*PageWithTimeout, error) {
+	// Create a new incognito page
+	page := browserInfo.Browser.MustIncognito().MustPage()
+
+	// Create PageWithTimeout
+	pwt := &PageWithTimeout{
+		Page:      page,
+		Browser:   browserInfo.Browser,
+		LastUsed:  time.Now(),
+		InUse:     false,
+		BrowserID: browserInfo.ID,
+	}
+
+	// Add to browser's pages
+	browserInfo.Pages = append(browserInfo.Pages, pwt)
+	browserInfo.PageCount++
+
+	sharedInfrastructure.GetLogger().
+		WithField("browser_id", browserInfo.ID).
+		Info("Created new page")
+
+	return pwt, nil
+}
+
+// findOrCreateAvailablePage finds an available page or creates a new one if needed
+func (p *PDFGeneratorRod) findOrCreateAvailablePage() (*PageWithTimeout, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	// Skip initialization if already done
-	if p.initialized {
-		return
+	// Check if there are available pages already
+	if len(p.availablePages) > 0 {
+		// Take the first available page
+		page := p.availablePages[0]
+		p.availablePages = p.availablePages[1:]
+
+		// Stop the timer if it's running
+		if page.Timer != nil {
+			page.Timer.Stop()
+		}
+
+		page.InUse = true
+		return page, nil
 	}
 
-	// Determine the optimal number of browsers based on system resources,
-	// but never exceed the defined maximum
-	numBrowsers := min(runtime.GOMAXPROCS(0), MaxBrowsers)
+	// Need to create a new page
 
-	// Create the page pool channel with capacity for all pages across all browsers
-	p.pagePool = make(chan *PageWithBrowser, numBrowsers*MaxPagesPerBrowser)
+	// First, see if we have any browser with capacity for a new page
+	for _, browserInfo := range p.browsers {
+		if browserInfo.PageCount < MaxPagesPerBrowser {
+			// This browser can take another page
+			page, err := p.createPage(browserInfo)
+			if err != nil {
+				return nil, err
+			}
 
-	// Create and configure each browser instance
-	for i := 0; i < numBrowsers; i++ {
-		// Launch a new browser instance with optimized settings for headless PDF generation
-		launcherURL := launcher.New().
-			Bin(sharedInfrastructure.GetEnvironment().ChromiumBinaryPath). // Use the configured Chromium binary
-			Headless(true).                                                // Run in headless mode (no UI)
-			Leakless(true).                                                // Ensure process cleanup on unexpected termination
-			Set("disable-gpu", "1").                                       // Disable GPU acceleration
-			Set("disable-dev-shm-usage", "1").                             // Avoid using shared memory
-			Set("disable-extensions", "1").                                // Disable browser extensions
-			MustLaunch()
-
-		// Connect to the launched browser
-		browser := rod.New().ControlURL(launcherURL).MustConnect()
-		p.browsers = append(p.browsers, browser)
-
-		// Create pages for this browser and add them to the page pool
-		for j := 0; j < MaxPagesPerBrowser; j++ {
-			page := browser.MustIncognito().MustPage() // Use incognito for isolation
-			p.pagePool <- &PageWithBrowser{Page: page, Browser: browser}
+			page.InUse = true
+			return page, nil
 		}
 	}
 
-	p.initialized = true
+	// No browser with capacity, need to create a new browser if allowed
+	if len(p.browsers) < MaxBrowsers {
+		browserInfo, err := p.createBrowser()
+		if err != nil {
+			return nil, err
+		}
 
-	// Log initialization details
-	sharedInfrastructure.GetLogger().
-		WithField("browsers", numBrowsers).
-		WithField("pages_total", numBrowsers*MaxPagesPerBrowser).
-		Info("PDF generator page pool initialized")
+		// Create a page in this new browser
+		page, err := p.createPage(browserInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		page.InUse = true
+		return page, nil
+	}
+
+	// All browsers are at capacity and we can't create more
+	// Create a channel to receive a page when one becomes available
+	pageChannel := make(chan *PageWithTimeout, 1)
+	p.waitingQueue = append(p.waitingQueue, pageChannel)
+
+	// Release the lock while waiting
+	p.mutex.Unlock()
+	page := <-pageChannel
+	p.mutex.Lock()
+
+	return page, nil
 }
 
-// RequestPage retrieves an available page from the page pool.
-// This method will block until a page becomes available if all pages are currently in use.
+// startPageTimer starts a timer to close the page after inactivity
+func (p *PDFGeneratorRod) startPageTimer(page *PageWithTimeout) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// Stop existing timer if any
+	if page.Timer != nil {
+		page.Timer.Stop()
+	}
+
+	// Start a new timer
+	page.Timer = time.AfterFunc(PageIdleTimeout, func() {
+		p.closeIdlePage(page)
+	})
+}
+
+// closeIdlePage closes a page that has been idle for too long
+func (p *PDFGeneratorRod) closeIdlePage(page *PageWithTimeout) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// Make sure the page is still in our pool and not in use
+	if page.InUse {
+		return
+	}
+
+	// Find the page in the available list
+	foundIdx := -1
+	for i, p := range p.availablePages {
+		if p == page {
+			foundIdx = i
+			break
+		}
+	}
+
+	if foundIdx != -1 {
+		// Remove from available pages
+		p.availablePages = slices.Delete(p.availablePages, foundIdx, foundIdx+1)
+
+		// Close the page
+		page.Page.MustClose()
+
+		// Update browser info
+		browserInfo := p.browsers[page.BrowserID]
+		browserInfo.PageCount--
+
+		// Remove from browser's pages list
+		for i, p := range browserInfo.Pages {
+			if p == page {
+				browserInfo.Pages = slices.Delete(browserInfo.Pages, i, i+1)
+				break
+			}
+		}
+
+		// If this was the last page, close the browser too
+		if browserInfo.PageCount == 0 {
+			browserInfo.Browser.MustClose()
+			delete(p.browsers, page.BrowserID)
+			sharedInfrastructure.GetLogger().
+				WithField("browser_id", page.BrowserID).
+				Info("Closed idle browser instance")
+		}
+
+		sharedInfrastructure.GetLogger().
+			WithField("browser_id", page.BrowserID).
+			Info("Closed idle page")
+	}
+}
+
+// RequestPage retrieves an available page or creates a new one.
+// This method will block if all allowed resources are in use until a page becomes available.
 // The caller is responsible for returning the page to the pool after use.
 func (p *PDFGeneratorRod) RequestPage() *PageWithBrowser {
-	return <-p.pagePool
+	p.pageWaitGroup.Add(1)
+
+	// Get a page (available or new)
+	page, err := p.findOrCreateAvailablePage()
+	if err != nil {
+		sharedInfrastructure.GetLogger().WithError(err).Error("Failed to get page")
+		p.pageWaitGroup.Done()
+		return nil
+	}
+
+	// Convert to the interface expected by existing code
+	return &PageWithBrowser{
+		Page:    page.Page,
+		Browser: page.Browser,
+	}
 }
 
-// ReturnPage returns a previously requested page back to the page pool,
-// making it available for future use by other operations.
+// ReturnPage returns a page to the pool and starts its inactivity timer.
 // This should be called after a page is no longer needed to prevent resource leaks.
 func (p *PDFGeneratorRod) ReturnPage(pwb *PageWithBrowser) {
-	p.pagePool <- pwb
+	defer p.pageWaitGroup.Done()
+	p.mutex.Lock()
+
+	// Find the corresponding PageWithTimeout
+	var page *PageWithTimeout
+	for _, browserInfo := range p.browsers {
+		for _, p := range browserInfo.Pages {
+			if p.Page == pwb.Page {
+				page = p
+				break
+			}
+		}
+		if page != nil {
+			break
+		}
+	}
+
+	// If the page is not found, just close it
+	if page == nil {
+		pwb.Page.MustClose()
+		p.mutex.Unlock()
+		return
+	}
+
+	// Mark as not in use and update timestamp
+	page.InUse = false
+	page.LastUsed = time.Now()
+
+	// Check if anyone is waiting for a page
+	if len(p.waitingQueue) > 0 {
+		// Give the page directly to the first waiter
+		ch := p.waitingQueue[0]
+		p.waitingQueue = p.waitingQueue[1:]
+
+		page.InUse = true
+		p.mutex.Unlock()
+
+		ch <- page
+	} else {
+		// No one waiting, add to available pages
+		p.availablePages = append(p.availablePages, page)
+		p.mutex.Unlock()
+
+		// Start the inactivity timer
+		p.startPageTimer(page)
+	}
 }
 
 // ReleaseBrowserPool cleans up all browser resources managed by this generator.
@@ -141,26 +372,38 @@ func (p *PDFGeneratorRod) ReturnPage(pwb *PageWithBrowser) {
 // This method is thread-safe and idempotent, so it's safe to call multiple times.
 func (p *PDFGeneratorRod) ReleaseBrowserPool() {
 	p.mutex.Lock()
+
+	// Wait for all pages to be returned
+	p.mutex.Unlock()
+	p.pageWaitGroup.Wait()
+	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	// Skip if not initialized
-	if !p.initialized {
-		return
+	// Close all browsers
+	for id, browserInfo := range p.browsers {
+		// Stop all timers
+		for _, page := range browserInfo.Pages {
+			if page.Timer != nil {
+				page.Timer.Stop()
+			}
+			// Close each page
+			page.Page.MustClose()
+		}
+
+		// Close the browser
+		browserInfo.Browser.MustClose()
+		delete(p.browsers, id)
 	}
 
-	// Close the page pool channel to prevent further page requests
-	close(p.pagePool)
+	// Clear pages
+	p.availablePages = make([]*PageWithTimeout, 0)
 
-	// Close each browser instance
-	for _, browser := range p.browsers {
-		browser.MustClose()
+	// Clear waiting queue and signal closure
+	for _, ch := range p.waitingQueue {
+		close(ch)
 	}
+	p.waitingQueue = make([]chan *PageWithTimeout, 0)
 
-	// Reset the state to allow for potential re-initialization
-	p.browsers = nil
-	p.initialized = false
-
-	// Log the cleanup
 	sharedInfrastructure.GetLogger().Info("PDF generator browser pool cleaned up")
 }
 
@@ -333,11 +576,6 @@ func (p *PDFGeneratorRod) mergePDFs(readers []io.Reader) (io.Reader, error) {
 // This method handles initializing the generator if needed and coordinates
 // the parallel generation of multiple PDF items.
 func (p *PDFGeneratorRod) GeneratePDF(request *dto.PDFGenerationDTO) (io.Reader, error) {
-	// Ensure generator is initialized
-	if !p.initialized {
-		p.Initialize()
-	}
-
 	// Prepare storage for individual PDF readers
 	readers := make([]io.Reader, len(request.Items))
 

--- a/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
+++ b/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
@@ -46,12 +46,11 @@ type PageWithBrowser struct {
 // PageWithTimeout extends PageWithBrowser to include timeout management.
 // This structure is used to track pages and their activity for dynamic resource management.
 type PageWithTimeout struct {
-	Page      *rod.Page    // The browser page instance for rendering content
-	Browser   *rod.Browser // The parent browser instance that owns this page
-	LastUsed  time.Time    // Timestamp when the page was last returned to the pool
-	Timer     *time.Timer  // Timer to track inactivity and trigger cleanup
-	InUse     bool         // Whether this page is currently being used
-	BrowserID string       // Unique identifier for the browser
+	PageWithBrowser
+	LastUsed  time.Time   // Timestamp when the page was last returned to the pool
+	Timer     *time.Timer // Timer to track inactivity and trigger cleanup
+	InUse     bool        // Whether this page is currently being used
+	BrowserID string      // Unique identifier for the browser
 }
 
 // BrowserInfo tracks information about a browser instance
@@ -142,8 +141,10 @@ func (p *PDFGeneratorRod) createPage(browserInfo *BrowserInfo) (*PageWithTimeout
 
 	// Create PageWithTimeout
 	pwt := &PageWithTimeout{
-		Page:      page,
-		Browser:   browserInfo.Browser,
+		PageWithBrowser: PageWithBrowser{
+			Page:    page,
+			Browser: browserInfo.Browser,
+		},
 		LastUsed:  time.Now(),
 		InUse:     false,
 		BrowserID: browserInfo.ID,

--- a/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
+++ b/internal/modules/pdf/infrastructure/implementations/pdf_generator_rod_implementation.go
@@ -372,11 +372,10 @@ func (p *PDFGeneratorRod) ReturnPage(pwb *PageWithBrowser) {
 // It closes all browser instances and releases associated resources.
 // This method is thread-safe and idempotent, so it's safe to call multiple times.
 func (p *PDFGeneratorRod) ReleaseBrowserPool() {
-	p.mutex.Lock()
-
-	// Wait for all pages to be returned
-	p.mutex.Unlock()
+	// Wait for all pages to finish processing before cleaning up
 	p.pageWaitGroup.Wait()
+
+	// Lock to ensure no concurrent access while cleaning up
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 

--- a/internal/modules/shared/infrastructure/environment.go
+++ b/internal/modules/shared/infrastructure/environment.go
@@ -24,6 +24,7 @@ type EnvironmentSpec struct {
 	// Concurrency
 	MaxChromiumBrowsers       int `split_words:"true" default:"1"`
 	MaxChromiumTabsPerBrowser int `split_words:"true" default:"4"`
+	MaxIdleSeconds            int `split_words:"true" default:"30"`
 
 	// AWS S3
 	AwsS3EndpointURL   string `split_words:"true" default:"https://s3.amazonaws.com"`


### PR DESCRIPTION
# Pull Request

Thank you for contributing to Serpentarius! Please check for similar PRs before creating a new one.

## Change Description

This PR implements an idle timeout mechanism for browser instances in the PDF generation microservice. Previously, a fixed number of browsers and pages were created during service initialization and remained open indefinitely, leading to unnecessary memory and CPU usage.

With this update, browser instances and their pages are automatically closed after a configurable period of inactivity. New instances are spawned on demand when PDF generation requests arrive. This change improves resource efficiency and ensures better scalability under low-load conditions.

## Testing

- Manually tested the microservice by sending PDF generation requests with various idle periods in between to confirm automatic shutdown and recreation of browser instances.
- Confirmed that new requests trigger browser reinitialization after timeout-based shutdown.

## Checklist

- [x] I have read and followed the contribution guidelines described in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.

## Additional Context

This change introduces an `MAX_IDLE_SECONDS` environment variable to configure the inactivity period before a browser instance is closed. Default is set to 30 seconds.

## Related Issues

Fixes #9 
